### PR TITLE
Add ERS button mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 
 bin/
 obj/
+.vs/
+calibration.json

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -425,6 +425,25 @@ class Program
             {
                 Console.WriteLine("No button press detected for Shift Down.");
             }
+            // ERS button
+            Console.WriteLine("\nPress and hold the ERS button.");
+            Console.WriteLine("Press ENTER when ready...");
+            Console.ReadLine();
+
+            var ersState = await WaitForStableInput(deviceGuid);
+            _calibration.ErsButton = FindPressedButton(ersState);
+
+            if (_calibration.ErsButton != -1)
+            {
+                Console.WriteLine($"ERS button detected: Button {_calibration.ErsButton}");
+            }
+            else
+            {
+                Console.WriteLine("No button press detected for ERS.");
+            }
+
+            Console.WriteLine("Release the button and wait...");
+            await Task.Delay(1000);
         }
         else
         {
@@ -432,6 +451,7 @@ class Program
             // Ensure buttons are disabled in calibration
             _calibration.ShiftUpButton = -1;
             _calibration.ShiftDownButton = -1;
+	        _calibration.ErsButton = -1;
         }
     }
     
@@ -642,6 +662,10 @@ class Program
             if (_calibration.ShiftDownButton >= 0 && _calibration.ShiftDownButton < shifterState.Buttons.Length)
             {
                 _controller.SetButtonState(Xbox360Button.X, shifterState.Buttons[_calibration.ShiftDownButton]);
+            }
+            if (_calibration.ErsButton >= 0 && _calibration.ErsButton < shifterState.Buttons.Length)
+            {       
+                _controller.SetButtonState(Xbox360Button.B, shifterState.Buttons[_calibration.ErsButton]);
             }
         }
         

--- a/src/WheelCalibration.cs
+++ b/src/WheelCalibration.cs
@@ -30,6 +30,7 @@ public class WheelCalibration
     // Button assignments
     public int ShiftUpButton { get; set; } = -1;
     public int ShiftDownButton { get; set; } = -1;
+    public int ErsButton { get; set; } = -1;
     
     public void SaveToFile(string filename)
     {


### PR DESCRIPTION
Adds configurable ERS button support to RoWheelBridge.

### Changes
- Added `ErsButton` to `WheelCalibration`
- Added ERS button calibration
- Maps the configured wheel button to Xbox B
- Added `calibration.json` to `.gitignore`
- Added `.vs/` to `.gitignore`

This allows a wheel button to control games that use Xbox B for ERS.